### PR TITLE
Framework flag shell completion

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -36,11 +36,49 @@ var (
 	allowedProjectTypes = []string{"chi", "gin", "fiber", "gorilla/mux", "httprouter", "standard-library", "echo"}
 )
 
+type framework string
+
+const (
+	Chi             framework = "chi"
+	Gin             framework = "gin"
+	fiber           framework = "fiber"
+	GorillaMux      framework = "gorilla/mux"
+	HttpRouter      framework = "httprouter"
+	StandardLibrary framework = "standard-library"
+	Echo            framework = "echo"
+)
+
+func (f *framework) String() string {
+	return string(*f)
+}
+
+func (f *framework) Type() string {
+	return "framework"
+}
+
+func (f *framework) Set(value string) error {
+	switch value {
+	case "chi", "gin", "fiber", "gorilla/mux", "httprouter", "standard-library", "echo":
+		*f = framework(value)
+		return nil
+	default:
+		return fmt.Errorf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", "))
+	}
+}
+
 func init() {
+	var frameworkFlag = Chi
 	rootCmd.AddCommand(createCmd)
 
 	createCmd.Flags().StringP("name", "n", "", "Name of project to create")
-	createCmd.Flags().StringP("framework", "f", "", fmt.Sprintf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", ")))
+	// createCmd.Flags().StringP("framework", "f", "", fmt.Sprintf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", ")))
+	createCmd.Flags().Var(&frameworkFlag, "framework", fmt.Sprintf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", ")))
+
+	createCmd.RegisterFlagCompletionFunc("framework", myFrameworkCompletion)
+}
+
+func myFrameworkCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    return allowedProjectTypes, cobra.ShellCompDirectiveDefault
 }
 
 // createCmd defines the "create" command for the CLI

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -36,49 +36,17 @@ var (
 	allowedProjectTypes = []string{"chi", "gin", "fiber", "gorilla/mux", "httprouter", "standard-library", "echo"}
 )
 
-type framework string
-
-const (
-	Chi             framework = "chi"
-	Gin             framework = "gin"
-	fiber           framework = "fiber"
-	GorillaMux      framework = "gorilla/mux"
-	HttpRouter      framework = "httprouter"
-	StandardLibrary framework = "standard-library"
-	Echo            framework = "echo"
-)
-
-func (f *framework) String() string {
-	return string(*f)
-}
-
-func (f *framework) Type() string {
-	return "framework"
-}
-
-func (f *framework) Set(value string) error {
-	switch value {
-	case "chi", "gin", "fiber", "gorilla/mux", "httprouter", "standard-library", "echo":
-		*f = framework(value)
-		return nil
-	default:
-		return fmt.Errorf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", "))
-	}
-}
-
 func init() {
-	var frameworkFlag = Chi
+	var frameworkFlag framework
+
 	rootCmd.AddCommand(createCmd)
 
 	createCmd.Flags().StringP("name", "n", "", "Name of project to create")
-	// createCmd.Flags().StringP("framework", "f", "", fmt.Sprintf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", ")))
-	createCmd.Flags().Var(&frameworkFlag, "framework", fmt.Sprintf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", ")))
+	createCmd.Flags().VarP(&frameworkFlag, "framework", "f", fmt.Sprintf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", ")))
 
-	createCmd.RegisterFlagCompletionFunc("framework", myFrameworkCompletion)
-}
-
-func myFrameworkCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-    return allowedProjectTypes, cobra.ShellCompDirectiveDefault
+	if err := createCmd.RegisterFlagCompletionFunc("framework", frameworkCompletion); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // createCmd defines the "create" command for the CLI

--- a/cmd/frameworkFlag.go
+++ b/cmd/frameworkFlag.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type framework string
+
+const (
+	Chi             framework = "chi"
+	Gin             framework = "gin"
+	fiber           framework = "fiber"
+	GorillaMux      framework = "gorilla/mux"
+	HttpRouter      framework = "httprouter"
+	StandardLibrary framework = "standard-library"
+	Echo            framework = "echo"
+)
+
+func (f *framework) String() string {
+	return string(*f)
+}
+
+func (f *framework) Type() string {
+	return "framework"
+}
+
+func (f *framework) Set(value string) error {
+	switch value {
+	case "chi", "gin", "fiber", "gorilla/mux", "httprouter", "standard-library", "echo":
+		*f = framework(value)
+		return nil
+	default:
+		return fmt.Errorf("Framework to use. Allowed values: %s", strings.Join(allowedProjectTypes, ", "))
+	}
+}
+
+func frameworkCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    return allowedProjectTypes, cobra.ShellCompDirectiveDefault
+}


### PR DESCRIPTION
Resolves #61

This pr adds shell completion for the `--framework` flag. This feature should
help users with discovering framework options, prevent typos and last but not
leas, typing less.
